### PR TITLE
Fix init center #34

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -537,15 +537,7 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       if (scene.appState) {
         scene.appState = {
           ...scene.appState,
-          ...calculateScrollCenter(
-            scene.elements,
-            {
-              ...scene.appState,
-              offsetTop: this.state.offsetTop,
-              offsetLeft: this.state.offsetLeft,
-            },
-            null,
-          ),
+          ...calculateScrollCenter(scene.elements, this.state, null),
         };
       }
       this.syncActionResult(scene);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -537,7 +537,17 @@ class App extends React.Component<ExcalidrawProps, AppState> {
       if (scene.appState) {
         scene.appState = {
           ...scene.appState,
-          ...calculateScrollCenter(scene.elements, this.state, null),
+          ...calculateScrollCenter(
+            scene.elements,
+            {
+              ...scene.appState,
+              width: this.state.width,
+              height: this.state.height,
+              offsetTop: this.state.offsetTop,
+              offsetLeft: this.state.offsetLeft,
+            },
+            null,
+          ),
         };
       }
       this.syncActionResult(scene);


### PR DESCRIPTION
Elements aren't being centered correctly because scene.appState isn't taking into account width and height props when passed.